### PR TITLE
resolved the admin dashboard bug

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,7 +1,7 @@
-import { initializeApp } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
-import { getStorage } from 'firebase/storage';
+import { getApps, initializeApp } from "firebase/app";
+import { getFirestore } from "firebase/firestore";
+import { getAuth } from "firebase/auth";
+import { getStorage } from "firebase/storage";
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -13,6 +13,26 @@ const firebaseConfig = {
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
   measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 };
+
+// APP DB
+const appFirebaseConfig = {
+  apiKey: import.meta.env.VITE_APP_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_APP_FIREBASE_AUTH_DOMAIN,
+  databaseURL: import.meta.env.VITE_APP_FIREBASE_DATABASE_URL,
+  projectId: import.meta.env.VITE_APP_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_APP_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_APP_FIREBASE_SENDER_ID,
+  appId: import.meta.env.VITE_APP_FIREBASE_APP_ID,
+  measurementId: import.meta.env.VITE_APP_FIREBASE_MEASUREMENT_ID,
+};
+
+const appFirebase =
+    getApps().find((app) => app.name === "appFirebase") ||
+    initializeApp(appFirebaseConfig, "appFirebase");
+
+export const appDB = getFirestore(appFirebase);
+export const appAuth = getAuth(appFirebase);
+export const appStorage = getStorage(appFirebase);
 
 export const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { collection, getDocs, doc, updateDoc, deleteDoc } from 'firebase/firestore';
-import { db } from '../lib/firebase';
+import { appDB } from '../lib/firebase';
 import { User , Car, X, Save, Edit, Plus } from 'lucide-react';
 import { Dialog } from '@headlessui/react';
 import { Input } from '../components/Input';
@@ -151,7 +151,8 @@ const AdminPage: React.FC = () => {
   useEffect(() => {
     const fetchUsers = async () => {
       try {
-        const querySnapshot = await getDocs(collection(db, 'partnerWebApp'));
+        const querySnapshot = await getDocs(collection(appDB, 'partnerAppVendors'));
+        
         const userList = querySnapshot.docs.map(doc => ({
           id: doc.id,
           username: doc.data().username || 'No Username',


### PR DESCRIPTION
🐛 Bug Description:
The admin dashboard was incorrectly fetching vendor data from the Zymo website Firebase database instead of the Zymo app Firebase database. Additionally, it was querying the wrong Firestore collection (partnerWebApp instead of partnerAppVendors), leading to missing or incorrect partner data in the admin panel.

🧠 Root Cause:
Used db (website Firebase) instead of appDB (app Firebase).

Queried the wrong collection name in the useEffect.

Environment variables for both website and app were not properly separated, causing incorrect Firebase initialization.